### PR TITLE
Fix register template

### DIFF
--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -1,4 +1,4 @@
-!DOCTYPE html>
+<!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
## Summary
- fix an incorrect `DOCTYPE` declaration in `register.html`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844653c4a248329b10503a43d0f6833